### PR TITLE
Finish note publication and url response for sharing

### DIFF
--- a/server/services/note/note_controller.js
+++ b/server/services/note/note_controller.js
@@ -1,12 +1,54 @@
+var Note = require('./note_model');
+
+var api = {
+  findNote: function(req, res, next, noteId) {
+    Note.findOne({ noteId: noteId }, api.handleNoteQuery.bind(api, req, next));
+  },
+  handleNoteQuery: function(req, next, err, note) {
+    if (err) {
+      next(err);
+    } else {
+      req.note = note;
+      next();
+    }
+  },
+  createNote: function(noteData, cb) {
+    var allNoteData = {
+      url: 'https://jotz-services.herokuapp.com/api/notes/' + noteData._id,
+      content: noteData,
+      noteId: noteData._id
+    }
+    Note.findOne({ noteId: noteData._id }, function(err, note) {
+      if (err) {
+        cb(err);
+      } else if (!note) {
+        Note.create(allNoteData, function(err, newNote) {
+          if (!err) {
+            cb(null, newNote.url);
+          } else {
+            cb(err);
+          }
+        });
+      } else {
+        cb(null, note.url);
+      }
+    });
+  }
+};
+
 module.exports = {
-  findNote: function(req, res, next) {
-    // lookup based on note _id
-    // add note to req.note
+  findNote: function(req, res, next, noteId) {
+    api.findNote(req, res, next, noteId);
   },
   publish: function(req, res, next) {
-    // lookup based on note _id
-      // if found, send back found url
-      // else, create new note and send back url
+    var noteData = req.body;
+    api.createNote(noteData, function(err, noteUrl) {
+      if (!err) {
+        res.status(200).send(noteUrl);
+      } else {
+        res.status(500).send(JSON.stringify(err));
+      }
+    });
   },
   display: function(req, res, next) {
       // if req.note, load note content into template

--- a/server/services/note/note_model.js
+++ b/server/services/note/note_model.js
@@ -1,12 +1,11 @@
 var mongoose = require('mongoose');
 
-
 var NoteSchema = new mongoose.Schema({
   url: { type: String },
   content: { type: Object },
+  noteId: { type: String },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });
-
 
 module.exports = mongoose.model('notes', NoteSchema);


### PR DESCRIPTION
1. POST to /api/notes/publish takes a single note in JSON and returns either an error or a url for sharing
2. need to finish the GET to /api/notes/:noteId for viewing the actual note, but that should be quick after lunch
3. I want to refactor later as well
