### PR TITLE
Finish basic note display of JSON blob

### DIFF
--- a/server/services/note/note_controller.js
+++ b/server/services/note/note_controller.js
@@ -51,7 +51,11 @@ module.exports = {
     });
   },
   display: function(req, res, next) {
-      // if req.note, load note content into template
-      // else, send back error
+    if (req.note) {
+      // TODO send back select note content within a template
+      res.status(200).send(JSON.stringify(req.note.content));
+    } else {
+      // TODO show error page
+    }
   }
 };


### PR DESCRIPTION
1. Displays the note content as JSON
   TODO: need to load parts of note content into a template and send that instead of JSON.
